### PR TITLE
Rename Boson -> Vector

### DIFF
--- a/projects/include/hamiltonian.hpp
+++ b/projects/include/hamiltonian.hpp
@@ -68,7 +68,7 @@ class Hamiltonian {
 };
 
 inline Real Hamiltonian::gross_pitaevskii_energy(const System &system, const Wavefunction &psi) const {
-    const int N = system.get_n_bosons();
+    const int N = system.get_n_particles();
     const int D = system.get_dimensions();
     const Real alpha = psi.get_alpha();
     const Real beta = psi.get_beta();

--- a/projects/include/interactingwavefunction.hpp
+++ b/projects/include/interactingwavefunction.hpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 #include "simplegaussian.hpp"
 
@@ -17,10 +17,10 @@ class InteractingWavefunction : public SimpleGaussian {
 
         virtual Real operator() (System&) const;
         virtual Real correlation(System&) const;
-        virtual Real drift_force(const Boson&, int) const;
+        virtual Real drift_force(const Vector&, int) const;
 };
 
-inline Real InteractingWavefunction::drift_force(const Boson &, int) const {
+inline Real InteractingWavefunction::drift_force(const Vector &, int) const {
     throw std::logic_error("Importance sampling not implemented for interacting system.");
 }
 

--- a/projects/include/rbmwavefunction.hpp
+++ b/projects/include/rbmwavefunction.hpp
@@ -53,7 +53,7 @@ class RBMWavefunction : public Wavefunction {
                            Real learning_rate);
 
         virtual Real derivative_alpha(const System&) const;
-        virtual Real drift_force(const Boson &, int) const;
+        virtual Real drift_force(const Vector &, int) const;
 
         const std::vector<Real>& get_visible_bias() const;
         const std::vector<Real>& get_hidden_bias() const;
@@ -62,7 +62,7 @@ class RBMWavefunction : public Wavefunction {
 inline Real RBMWavefunction::derivative_alpha(const System&) const {
     throw std::logic_error("Function not defined for RBM, only here for bad design reasons.");
 }
-inline Real RBMWavefunction::drift_force(const Boson &, int) const {
+inline Real RBMWavefunction::drift_force(const Vector &, int) const {
     throw std::logic_error("Function not implemented.");
 }
 inline const std::vector<Real>& RBMWavefunction::get_visible_bias() const {

--- a/projects/include/sampler.hpp
+++ b/projects/include/sampler.hpp
@@ -84,7 +84,7 @@ inline const System& Sampler::get_current_system() const {
 }
 inline void Sampler::prepare_for_next_run() {
     _total_steps++;
-    _particle_to_move = (_particle_to_move + 1) % _system_old.get_n_bosons();
+    _particle_to_move = (_particle_to_move + 1) % _system_old.get_n_particles();
 }
 inline std::ostream& operator<<(std::ostream &strm, const Sampler& s) {
     return strm << "Sampler(step=" << s._step << ")";

--- a/projects/include/simplegaussian.hpp
+++ b/projects/include/simplegaussian.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 #include "wavefunction.hpp"
 
@@ -15,9 +15,9 @@ class SimpleGaussian : public Wavefunction {
 
         virtual Real operator() (System&) const;
         virtual Real derivative_alpha(const System&) const;
-        virtual Real drift_force(const Boson&, int dim_index) const;
+        virtual Real drift_force(const Vector&, int dim_index) const;
 };
 
-inline Real SimpleGaussian::drift_force(const Boson &boson, int dim_index) const {
+inline Real SimpleGaussian::drift_force(const Vector &boson, int dim_index) const {
     return -4 * _alpha * (dim_index == 2 ? _beta : 1) * boson[dim_index];
 }

--- a/projects/include/system.hpp
+++ b/projects/include/system.hpp
@@ -7,25 +7,25 @@
 
 
 /**
- * Class representing a system of Bosons.
+ * Class representing a system of particles.
  */
 class System {
 
-    std::vector<Vector> _bosons;
+    std::vector<Vector> _particles;
     std::vector<std::vector<Real>> _distances;
     std::vector<std::vector<bool>> _dirty;
 
     public:
 
         /**
-         * Initialize a system of N D-dimensional bosons, placed at origin.
-         * @param number_of_bosons N
+         * Initialize a system of N D-dimensional particles, placed at origin.
+         * @param number_of_particles N
          * @param dimensions D
          */
-        System(int number_of_bosons, int dimensions);
+        System(int number_of_particles, int dimensions);
         /**
-         * @param index Index of Boson.
-         * @return Boson at given index.
+         * @param index Index of particle.
+         * @return particle at given index.
          */
         const Vector& operator[] (int index) const;
 
@@ -49,9 +49,9 @@ class System {
         bool operator!= (const System &other) const;
 
         /**
-         * @return Internal representation of all Bosons.
+         * @return Internal representation of all particles.
          */
-        const std::vector<Vector>& get_bosons() const;
+        const std::vector<Vector>& get_particles() const;
 
         const std::vector<std::vector<bool> > get_dirty() const;
 
@@ -61,42 +61,42 @@ class System {
         int get_dimensions() const;
 
         /**
-         * @return Number of Bosons in the System.
+         * @return Number of particles in the System.
          */
-        int get_n_bosons() const;
+        int get_n_particles() const;
 };
 
 inline const Vector& System::operator[] (int index) const {
-    assert(0 <= index and index < get_n_bosons());
-    return _bosons[index];
+    assert(0 <= index and index < get_n_particles());
+    return _particles[index];
 }
 inline Real System::degree(int k) const {
-    return _bosons[k / get_dimensions()][k % get_dimensions()];
+    return _particles[k / get_dimensions()][k % get_dimensions()];
 }
 inline bool System::operator== (const System &other) const {
-    return _bosons == other.get_bosons();
+    return _particles == other.get_particles();
 }
 inline bool System::operator!= (const System &other) const {
-    return _bosons != other.get_bosons();
+    return _particles != other.get_particles();
 }
-inline const std::vector<Vector>& System::get_bosons() const {
-    return _bosons;
+inline const std::vector<Vector>& System::get_particles() const {
+    return _particles;
 }
 inline const std::vector<std::vector<bool>> System::get_dirty() const {
     return _dirty;
 }
 inline int System::get_dimensions() const {
-    assert(get_n_bosons() > 0);
-    return _bosons[0].get_dimensions();
+    assert(get_n_particles() > 0);
+    return _particles[0].get_dimensions();
 }
-inline int System::get_n_bosons() const {
-    return _bosons.size();
+inline int System::get_n_particles() const {
+    return _particles.size();
 }
 inline std::ostream& operator<<(std::ostream &strm, const System &s) {
     strm << "System(";
-    for (int i = 0; i < s.get_n_bosons() - 1; i++)
+    for (int i = 0; i < s.get_n_particles() - 1; i++)
         strm << s[i] << ", ";
-    strm << s[s.get_n_bosons() - 1] << ")";
+    strm << s[s.get_n_particles() - 1] << ")";
     return strm;
 }
 

--- a/projects/include/system.hpp
+++ b/projects/include/system.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cassert>
 #include <iostream>
-#include "boson.hpp"
+#include "vector.hpp"
 
 
 /**
@@ -11,7 +11,7 @@
  */
 class System {
 
-    std::vector<Boson> _bosons;
+    std::vector<Vector> _bosons;
     std::vector<std::vector<Real>> _distances;
     std::vector<std::vector<bool>> _dirty;
 
@@ -27,9 +27,9 @@ class System {
          * @param index Index of Boson.
          * @return Boson at given index.
          */
-        const Boson& operator[] (int index) const;
+        const Vector& operator[] (int index) const;
 
-        Boson& operator() (int index);
+        Vector& operator() (int index);
 
         Real degree(int k) const;
 
@@ -51,7 +51,7 @@ class System {
         /**
          * @return Internal representation of all Bosons.
          */
-        const std::vector<Boson>& get_bosons() const;
+        const std::vector<Vector>& get_bosons() const;
 
         const std::vector<std::vector<bool> > get_dirty() const;
 
@@ -66,7 +66,7 @@ class System {
         int get_n_bosons() const;
 };
 
-inline const Boson& System::operator[] (int index) const {
+inline const Vector& System::operator[] (int index) const {
     assert(0 <= index and index < get_n_bosons());
     return _bosons[index];
 }
@@ -79,7 +79,7 @@ inline bool System::operator== (const System &other) const {
 inline bool System::operator!= (const System &other) const {
     return _bosons != other.get_bosons();
 }
-inline const std::vector<Boson>& System::get_bosons() const {
+inline const std::vector<Vector>& System::get_bosons() const {
     return _bosons;
 }
 inline const std::vector<std::vector<bool>> System::get_dirty() const {

--- a/projects/include/vector.hpp
+++ b/projects/include/vector.hpp
@@ -7,7 +7,7 @@
 /**
  * N-dimensional vector representation of a boson.
  */
-class Boson {
+class Vector {
     private:
         std::vector<Real> _pos;
 
@@ -17,12 +17,12 @@ class Boson {
          * Initialize a Boson with a given number of dimensions, initialized to origo.
          * @param dimensions Number of dimensions to use.
          */
-        Boson(int dimensions);
+        Vector(int dimensions);
         /**
          * Initialize a Boson from a std::vector.
          * @param vec Vector of initialization values.
          */
-        Boson(const std::vector<Real> &vec);
+        Vector(const std::vector<Real> &vec);
         /**
          * @return Internal position vector.
          */
@@ -45,19 +45,19 @@ class Boson {
         /**
          * Stream text representation of the Boson to a stream.
          */
-        friend std::ostream& operator<<(std::ostream&, const Boson&);
+        friend std::ostream& operator<<(std::ostream&, const Vector&);
 };
 
-inline Real& Boson::operator[] (int dimension) {
+inline Real& Vector::operator[] (int dimension) {
     return _pos[dimension];
 }
-inline Real Boson::operator[] (int dimension) const {
+inline Real Vector::operator[] (int dimension) const {
     return _pos[dimension];
 }
-inline const std::vector<Real>& Boson::get_position() const {
+inline const std::vector<Real>& Vector::get_position() const {
     return _pos;
 }
-inline int Boson::get_dimensions() const {
+inline int Vector::get_dimensions() const {
     return _pos.size();
 }
 
@@ -66,13 +66,13 @@ inline int Boson::get_dimensions() const {
  * @param rhs Rhs. of the equality check.
  * @return Result of `==` on the underlying container.
  */
-inline bool operator== (const Boson &lhs, const Boson &rhs) {
+inline bool operator== (const Vector &lhs, const Vector &rhs) {
     return lhs.get_position() == rhs.get_position();
 }
 /*
  * @return Result of `!(lhs == rhs)`.
  */
-inline bool operator!= (const Boson &lhs, const Boson &rhs) {
+inline bool operator!= (const Vector &lhs, const Vector &rhs) {
     return !(lhs == rhs);
 }
 
@@ -89,23 +89,23 @@ inline bool operator!= (const Boson &lhs, const Boson &rhs) {
  * provided for each operator declaration.
  */
 
-Real operator* (const Boson &lhs, const Boson& rhs);
-Boson operator* (Boson lhs, Real rhs);
-Boson operator+ (Boson lhs, const Boson &rhs);
-Boson operator+ (Boson lhs, Real rhs);
-Boson operator+ (Real lhs, Boson rhs);
-Boson operator- (Boson lhs, const Boson &rhs);
-Boson operator- (Boson lhs, Real rhs);
-Boson operator- (Real lhs, Boson rhs);
-Boson operator/ (Boson lhs, Real rhs);
-Boson operator/ (Real lhs, Boson rhs);
+Real operator* (const Vector &lhs, const Vector& rhs);
+Vector operator* (Vector lhs, Real rhs);
+Vector operator+ (Vector lhs, const Vector &rhs);
+Vector operator+ (Vector lhs, Real rhs);
+Vector operator+ (Real lhs, Vector rhs);
+Vector operator- (Vector lhs, const Vector &rhs);
+Vector operator- (Vector lhs, Real rhs);
+Vector operator- (Real lhs, Vector rhs);
+Vector operator/ (Vector lhs, Real rhs);
+Vector operator/ (Real lhs, Vector rhs);
 
-Boson& operator+= (Boson &lhs, const Boson &rhs);
-Boson& operator+= (Boson &lhs, Real rhs);
-Boson& operator*= (Boson &lhs, Real rhs);
-Boson& operator-= (Boson &lhs, const Boson &rhs);
-Boson& operator-= (Boson &lhs, Real rhs);
-Boson& operator/= (Boson &lhs, Real rhs);
+Vector& operator+= (Vector &lhs, const Vector &rhs);
+Vector& operator+= (Vector &lhs, Real rhs);
+Vector& operator*= (Vector &lhs, Real rhs);
+Vector& operator-= (Vector &lhs, const Vector &rhs);
+Vector& operator-= (Vector &lhs, Real rhs);
+Vector& operator/= (Vector &lhs, Real rhs);
 
 
 

--- a/projects/include/vmc.hpp
+++ b/projects/include/vmc.hpp
@@ -2,7 +2,7 @@
 
 /* Convenience include for all headers. */
 
-#include "boson.hpp"
+#include "vector.hpp"
 #include "config.hpp.in"
 #include "definitions.hpp"
 #include "hamiltonian.hpp"

--- a/projects/include/wavefunction.hpp
+++ b/projects/include/wavefunction.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 
 /**
@@ -40,7 +40,7 @@ class Wavefunction {
          * @param dimension Component to evaluate.
          * @return Given component of the drift force on the Boson.
          */
-        virtual Real drift_force(const Boson &boson, int dimension) const = 0;
+        virtual Real drift_force(const Vector &boson, int dimension) const = 0;
         Real get_alpha() const;
         Real get_beta() const;
         Real get_a() const;

--- a/projects/src/hamiltonian.cpp
+++ b/projects/src/hamiltonian.cpp
@@ -8,9 +8,9 @@
 Hamiltonian::Hamiltonian(Real omega_z, Real a, Real h) : _omega_z(omega_z), _a(a), _h(h) {}
 
 Real Hamiltonian::kinetic_energy(System &system, const Wavefunction &psi) const {
-    Real E_k = -2 * (system.get_n_bosons() * system.get_dimensions()) * psi(system);
+    Real E_k = -2 * (system.get_n_particles() * system.get_dimensions()) * psi(system);
 
-    for (int i = 0; i < system.get_n_bosons(); ++i) {
+    for (int i = 0; i < system.get_n_particles(); ++i) {
         for (int d = 0; d < system.get_dimensions(); ++d) {
             const auto temp = system[i][d];
             system(i)[d] = temp + _h;

--- a/projects/src/harmonicoscillatorhamiltonian.cpp
+++ b/projects/src/harmonicoscillatorhamiltonian.cpp
@@ -9,7 +9,7 @@ Real HarmonicOscillatorHamiltonian::local_energy(System &system, const Wavefunct
 
     Real E_L = 0;
 
-    for (int k = 0; k < system.get_n_bosons(); ++k) {
+    for (int k = 0; k < system.get_n_particles(); ++k) {
 
         Vector r_k = system[k];
         if (system.get_dimensions() == 3) {
@@ -25,7 +25,7 @@ Real HarmonicOscillatorHamiltonian::local_energy(System &system, const Wavefunct
 Real HarmonicOscillatorHamiltonian::external_potential(System &system) const {
     Real pot = 0;
 
-    for (int i = 0; i < system.get_n_bosons(); ++i) {
+    for (int i = 0; i < system.get_n_particles(); ++i) {
         if (system.get_dimensions() == 3) {
             pot += square(system[i][0]) + square(system[i][1]) + square(_omega_z * system[i][2]);
         } else {

--- a/projects/src/harmonicoscillatorhamiltonian.cpp
+++ b/projects/src/harmonicoscillatorhamiltonian.cpp
@@ -11,7 +11,7 @@ Real HarmonicOscillatorHamiltonian::local_energy(System &system, const Wavefunct
 
     for (int k = 0; k < system.get_n_bosons(); ++k) {
 
-        Boson r_k = system[k];
+        Vector r_k = system[k];
         if (system.get_dimensions() == 3) {
             r_k[2] *= beta;
         }

--- a/projects/src/importancesampler.cpp
+++ b/projects/src/importancesampler.cpp
@@ -13,7 +13,7 @@ ImportanceSampler::ImportanceSampler(const System &system,
 }
 
 void ImportanceSampler::initialize_system() {
-    for (int i = 0; i < _system_old.get_n_bosons(); ++i) {
+    for (int i = 0; i < _system_old.get_n_particles(); ++i) {
         for (int d = 0; d < _system_old.get_dimensions(); ++d) {
             _system_old(i)[d] = rnorm(rand_gen) * std::sqrt(_step);
         }

--- a/projects/src/importancesampler.cpp
+++ b/projects/src/importancesampler.cpp
@@ -22,7 +22,7 @@ void ImportanceSampler::initialize_system() {
 }
 
 void ImportanceSampler::perturb_system() {
-    Boson &boson = _system_new(_particle_to_move);
+    Vector &boson = _system_new(_particle_to_move);
 
     for (int d = 0; d < boson.get_dimensions(); ++d) {
         boson[d] += rnorm(rand_gen) * std::sqrt(_step)
@@ -33,8 +33,8 @@ void ImportanceSampler::perturb_system() {
 }
 
 Real ImportanceSampler::acceptance_probability() const {
-    const Boson &r_old = _system_old[_particle_to_move];
-    const Boson &r_new = _system_new[_particle_to_move];
+    const Vector &r_old = _system_old[_particle_to_move];
+    const Vector &r_new = _system_new[_particle_to_move];
 
     Real green1 = 0, green2 = 0;
     for (int d = 0; d < r_old.get_dimensions(); ++d) {

--- a/projects/src/interactinghamiltonian.cpp
+++ b/projects/src/interactinghamiltonian.cpp
@@ -18,7 +18,7 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
 
     Real E_L = 0;
 
-    for (int k = 0; k < system.get_n_bosons(); ++k) {
+    for (int k = 0; k < system.get_n_particles(); ++k) {
 
         const Vector &r_k = system[k];
         Vector r_k_hat = system[k];
@@ -33,7 +33,7 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
         Vector term1 (system.get_dimensions());
         Real term2 = 0;
         Real term3 = 0;
-        for (int j = 0; j < system.get_n_bosons(); ++j) {
+        for (int j = 0; j < system.get_n_particles(); ++j) {
             if (j == k) continue;
             const Vector r_kj = r_k - system[j];
             const Real r_kj_norm = system.distance(k, j);
@@ -43,7 +43,7 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
             term3 += _a * (_a - 2*r_kj_norm) / (square(r_kj_norm) * square(r_kj_norm - _a))
                 + 2 * _a / (square(r_kj_norm) * (r_kj_norm - _a));
 
-            for (int i = 0; i < system.get_n_bosons(); ++i) {
+            for (int i = 0; i < system.get_n_particles(); ++i) {
                 if (i == k) continue;
                 const Vector r_ki = r_k - system[i];
                 const Real r_ki_norm = system.distance(k, i);
@@ -62,8 +62,8 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
 
 Real InteractingHamiltonian::internal_potential(System &system) const {
 
-    for (int i = 0; i < system.get_n_bosons() - 1; ++i) {
-        for (int j = i + 1; j < system.get_n_bosons(); ++j) {
+    for (int i = 0; i < system.get_n_particles() - 1; ++i) {
+        for (int j = i + 1; j < system.get_n_particles(); ++j) {
             if (system.distance(i, j) <= _a)
                 return std::numeric_limits<Real>::max();
         }

--- a/projects/src/interactinghamiltonian.cpp
+++ b/projects/src/interactinghamiltonian.cpp
@@ -20,8 +20,8 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
 
     for (int k = 0; k < system.get_n_bosons(); ++k) {
 
-        const Boson &r_k = system[k];
-        Boson r_k_hat = system[k];
+        const Vector &r_k = system[k];
+        Vector r_k_hat = system[k];
         if (system.get_dimensions() == 3) {
             r_k_hat[2] *= beta;
         }
@@ -30,12 +30,12 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
 
         // Interaction terms:
 
-        Boson term1 (system.get_dimensions());
+        Vector term1 (system.get_dimensions());
         Real term2 = 0;
         Real term3 = 0;
         for (int j = 0; j < system.get_n_bosons(); ++j) {
             if (j == k) continue;
-            const Boson r_kj = r_k - system[j];
+            const Vector r_kj = r_k - system[j];
             const Real r_kj_norm = system.distance(k, j);
 
             term1 += r_kj * (_a / (square(r_kj_norm) * (r_kj_norm - _a)));
@@ -45,7 +45,7 @@ Real InteractingHamiltonian::local_energy(System &system, const Wavefunction &ps
 
             for (int i = 0; i < system.get_n_bosons(); ++i) {
                 if (i == k) continue;
-                const Boson r_ki = r_k - system[i];
+                const Vector r_ki = r_k - system[i];
                 const Real r_ki_norm = system.distance(k, i);
 
                 term2 += (r_ki * r_kj) * square(_a) / (square(r_ki_norm * r_kj_norm) * (r_ki_norm - _a) * (r_kj_norm - _a));

--- a/projects/src/interactingwavefunction.cpp
+++ b/projects/src/interactingwavefunction.cpp
@@ -8,8 +8,8 @@
 
 Real InteractingWavefunction::correlation(System &system) const {
     Real f = 1;
-    for (int i = 0; i < system.get_n_bosons() - 1; ++i) {
-        for (int j = i + 1; j < system.get_n_bosons(); ++j) {
+    for (int i = 0; i < system.get_n_particles() - 1; ++i) {
+        for (int j = i + 1; j < system.get_n_particles(); ++j) {
 
             Real r_ij = system.distance(i, j);
 

--- a/projects/src/interactingwavefunction.cpp
+++ b/projects/src/interactingwavefunction.cpp
@@ -2,7 +2,7 @@
 #include <cassert>
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 #include "interactingwavefunction.hpp"
 

--- a/projects/src/metropolissampler.cpp
+++ b/projects/src/metropolissampler.cpp
@@ -13,7 +13,7 @@ MetropolisSampler::MetropolisSampler(const System &system,
 }
 
 void MetropolisSampler::initialize_system() {
-    for (int i = 0; i < _system_old.get_n_bosons(); ++i) {
+    for (int i = 0; i < _system_old.get_n_particles(); ++i) {
         for (int d = 0; d < _system_old.get_dimensions(); ++d) {
             _system_old(i)[d] = _step * centered(rand_gen);
         }

--- a/projects/src/onebodydensitycalculator.cpp
+++ b/projects/src/onebodydensitycalculator.cpp
@@ -37,7 +37,7 @@ OneBodyDensityCalculator::OneBodyDensityCalculator(const Wavefunction &wavefunct
 }
 
 void OneBodyDensityCalculator::process_state(System &system) {
-    for (const Boson &boson : system.get_bosons()) {
+    for (const Vector &boson : system.get_bosons()) {
         Real r_k = std::sqrt(square(boson));
         if (r_k < _max_radius) {
             _bins[(int) (r_k / _r_step)]++;

--- a/projects/src/onebodydensitycalculator.cpp
+++ b/projects/src/onebodydensitycalculator.cpp
@@ -37,7 +37,7 @@ OneBodyDensityCalculator::OneBodyDensityCalculator(const Wavefunction &wavefunct
 }
 
 void OneBodyDensityCalculator::process_state(System &system) {
-    for (const Vector &boson : system.get_bosons()) {
+    for (const Vector &boson : system.get_particles()) {
         Real r_k = std::sqrt(square(boson));
         if (r_k < _max_radius) {
             _bins[(int) (r_k / _r_step)]++;

--- a/projects/src/rbmharmonicoscillatorhamiltonian.cpp
+++ b/projects/src/rbmharmonicoscillatorhamiltonian.cpp
@@ -5,7 +5,7 @@
 
 Real RBMHarmonicOscillatorHamiltonian::external_potential(System &system) const {
     Real res = 0;
-    for (auto &&particle : system.get_bosons()) {
+    for (auto &&particle : system.get_particles()) {
         res += square(particle);
     }
     return 0.5 * res;

--- a/projects/src/rbmwavefunction.cpp
+++ b/projects/src/rbmwavefunction.cpp
@@ -35,7 +35,7 @@ Real RBMWavefunction::v_j(int j, System &system) const {
 
 Real RBMWavefunction::operator() (System &system) const {
 
-    assert(system.get_dimensions() * system.get_n_bosons() == _M);
+    assert(system.get_dimensions() * system.get_n_particles() == _M);
 
     Real u = 0;
     for (int i = 0; i < _M; ++i) {

--- a/projects/src/simplegaussian.cpp
+++ b/projects/src/simplegaussian.cpp
@@ -9,11 +9,11 @@ namespace {
     Real exponent(const System &system, Real beta) {
         Real g = 0;
         if (system.get_dimensions() == 3) {
-            for (const Vector &boson : system.get_bosons()) {
+            for (const Vector &boson : system.get_particles()) {
                 g += square(boson[0]) + square(boson[1]) + beta * square(boson[2]);
             }
         } else {
-            for (const Vector &boson : system.get_bosons()) {
+            for (const Vector &boson : system.get_particles()) {
                 g += square(boson);
             }
         }

--- a/projects/src/simplegaussian.cpp
+++ b/projects/src/simplegaussian.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 #include "simplegaussian.hpp"
 
@@ -9,11 +9,11 @@ namespace {
     Real exponent(const System &system, Real beta) {
         Real g = 0;
         if (system.get_dimensions() == 3) {
-            for (const Boson &boson : system.get_bosons()) {
+            for (const Vector &boson : system.get_bosons()) {
                 g += square(boson[0]) + square(boson[1]) + beta * square(boson[2]);
             }
         } else {
-            for (const Boson &boson : system.get_bosons()) {
+            for (const Vector &boson : system.get_bosons()) {
                 g += square(boson);
             }
         }

--- a/projects/src/system.cpp
+++ b/projects/src/system.cpp
@@ -1,10 +1,10 @@
 #include <vector>
 #include <cassert>
-#include "boson.hpp"
+#include "vector.hpp"
 #include "system.hpp"
 
 System::System(int number_of_bosons, int dimensions) :
-    _bosons(number_of_bosons, Boson{dimensions}),
+    _bosons(number_of_bosons, Vector{dimensions}),
     _distances(number_of_bosons, std::vector<Real>(number_of_bosons, 0)),
     _dirty(number_of_bosons, std::vector<bool>(number_of_bosons, true))
 { }
@@ -19,7 +19,7 @@ Real System::distance(int i, int j) {
     return _distances[i][j];
 }
 
-Boson& System::operator() (int index) {
+Vector& System::operator() (int index) {
     assert(0 <= index and index < get_n_bosons());
     auto n = get_n_bosons();
     for (int i = 0; i < n; ++i)

--- a/projects/src/system.cpp
+++ b/projects/src/system.cpp
@@ -3,26 +3,26 @@
 #include "vector.hpp"
 #include "system.hpp"
 
-System::System(int number_of_bosons, int dimensions) :
-    _bosons(number_of_bosons, Vector{dimensions}),
-    _distances(number_of_bosons, std::vector<Real>(number_of_bosons, 0)),
-    _dirty(number_of_bosons, std::vector<bool>(number_of_bosons, true))
+System::System(int number_of_particles, int dimensions) :
+    _particles(number_of_particles, Vector{dimensions}),
+    _distances(number_of_particles, std::vector<Real>(number_of_particles, 0)),
+    _dirty(number_of_particles, std::vector<bool>(number_of_particles, true))
 { }
 
 Real System::distance(int i, int j) {
-    assert(0 <= i and i < get_n_bosons());
-    assert(0 <= j and j < get_n_bosons());
+    assert(0 <= i and i < get_n_particles());
+    assert(0 <= j and j < get_n_particles());
     if (_dirty[i][j]) {
-        _distances[i][j] = _distances[j][i] = std::sqrt(square(_bosons[i] - _bosons[j]));
+        _distances[i][j] = _distances[j][i] = std::sqrt(square(_particles[i] - _particles[j]));
         _dirty[i][j] = _dirty[j][i] = false;
     }
     return _distances[i][j];
 }
 
 Vector& System::operator() (int index) {
-    assert(0 <= index and index < get_n_bosons());
-    auto n = get_n_bosons();
+    assert(0 <= index and index < get_n_particles());
+    auto n = get_n_particles();
     for (int i = 0; i < n; ++i)
         _dirty[index][i] = _dirty[i][index] = true;
-    return _bosons[index];
+    return _particles[index];
 }

--- a/projects/src/vector.cpp
+++ b/projects/src/vector.cpp
@@ -2,9 +2,9 @@
 #include <cassert>
 #include <iostream>
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 
-Boson::Boson(int dimensions) : _pos(dimensions, 0.0) {
+Vector::Vector(int dimensions) : _pos(dimensions, 0.0) {
     // Dimension expected to be in [1, 3]. Nothing about the
     // implementation should break for Dim >= 4, but if this is
     // used, it is more likely a programmer typo/bug.
@@ -14,9 +14,9 @@ Boson::Boson(int dimensions) : _pos(dimensions, 0.0) {
 /*
  * Allowed for simplicity in creating test instances.
  */
-Boson::Boson(const std::vector<Real> &pos) : _pos(pos) { }
+Vector::Vector(const std::vector<Real> &pos) : _pos(pos) { }
 
-Real operator* (const Boson &lhs, const Boson &rhs) {
+Real operator* (const Vector &lhs, const Vector &rhs) {
     assert(lhs.get_dimensions() == rhs.get_dimensions());
     Real prod = 0;
     for (int i = 0; i < lhs.get_dimensions(); i++) {
@@ -24,27 +24,27 @@ Real operator* (const Boson &lhs, const Boson &rhs) {
     }
     return prod;
 }
-Boson& operator+= (Boson &lhs, const Boson &rhs) {
+Vector& operator+= (Vector &lhs, const Vector &rhs) {
     assert(lhs.get_dimensions() == rhs.get_dimensions());
     for (int i = 0; i < lhs.get_dimensions(); i++) {
         lhs[i] += rhs[i];
     }
     return lhs;
 }
-Boson& operator-= (Boson &lhs, const Boson &rhs) {
+Vector& operator-= (Vector &lhs, const Vector &rhs) {
     assert(lhs.get_dimensions() == rhs.get_dimensions());
     for (int i = 0; i < lhs.get_dimensions(); i++) {
         lhs[i] -= rhs[i];
     }
     return lhs;
 }
-Boson& operator+= (Boson &lhs, Real rhs) {
+Vector& operator+= (Vector &lhs, Real rhs) {
     for (int i = 0; i < lhs.get_dimensions(); i++) {
         lhs[i] += rhs;
     }
     return lhs;
 }
-Boson& operator*= (Boson &lhs, Real rhs) {
+Vector& operator*= (Vector &lhs, Real rhs) {
     for (int i = 0; i < lhs.get_dimensions(); i++) {
         lhs[i] *= rhs;
     }
@@ -57,41 +57,41 @@ Boson& operator*= (Boson &lhs, Real rhs) {
  * efficiency hit, but the compiler should be able to minimize this well.
  */
 
-Boson& operator-= (Boson &lhs, Real rhs) {
+Vector& operator-= (Vector &lhs, Real rhs) {
     return lhs += -rhs;
 }
-Boson& operator/= (Boson &lhs, Real rhs) {
+Vector& operator/= (Vector &lhs, Real rhs) {
     return lhs *= 1/rhs;
 }
 
-Boson operator+ (Boson lhs, const Boson &rhs) {
+Vector operator+ (Vector lhs, const Vector &rhs) {
     return lhs += rhs;
 }
-Boson operator+ (Boson lhs, Real rhs) {
+Vector operator+ (Vector lhs, Real rhs) {
     return lhs += rhs;
 }
-Boson operator+ (Real lhs, Boson rhs) {
+Vector operator+ (Real lhs, Vector rhs) {
     return rhs += lhs;
 }
-Boson operator-(Boson lhs, const Boson &rhs) {
+Vector operator-(Vector lhs, const Vector &rhs) {
     return lhs -= rhs;
 }
-Boson operator- (Boson lhs, Real rhs) {
+Vector operator- (Vector lhs, Real rhs) {
     return lhs -= rhs;
 }
-Boson operator- (Real lhs, Boson rhs) {
+Vector operator- (Real lhs, Vector rhs) {
     return (rhs -= lhs) *= -1;
 }
-Boson operator/ (Boson lhs, Real rhs) {
+Vector operator/ (Vector lhs, Real rhs) {
     return lhs /= rhs;
 }
-Boson operator* (Boson lhs, Real rhs) {
+Vector operator* (Vector lhs, Real rhs) {
     return lhs *= rhs;
 }
-Boson operator* (Real lhs, Boson rhs) {
+Vector operator* (Real lhs, Vector rhs) {
     return rhs *= lhs;
 }
-std::ostream& operator<<(std::ostream &strm, const Boson &b) {
+std::ostream& operator<<(std::ostream &strm, const Vector &b) {
     strm << "Boson(";
     for (int i = 0; i < b.get_dimensions() - 1; i++)
         strm << b[i] << ", ";

--- a/projects/tests/harmonicoscillatorhamiltonian.cpp
+++ b/projects/tests/harmonicoscillatorhamiltonian.cpp
@@ -87,11 +87,11 @@ TEST_F(HarmonicOscillatorHamiltonianTest, local_energy_simple) {
     // 1000, why not?
     for (int runs = 0; runs < 1000; ++runs) {
         System s (dim_gen() * dim_gen() * dim_gen() * dim_gen(), dim_gen());
-        for (int i = 0; i < s.get_n_bosons(); ++i) {
+        for (int i = 0; i < s.get_n_particles(); ++i) {
             s(i) = {{ double_gen(), double_gen(), double_gen() }};
         }
 
-        Real expected = alpha * s.get_dimensions() * s.get_n_bosons();
+        Real expected = alpha * s.get_dimensions() * s.get_n_particles();
         ASSERT_NEAR(expected, H_1.local_energy(s, psi), expected * 1e-15);
         ASSERT_NEAR(expected, H_1.local_energy_numeric(s, psi), expected * 1e-6);
     }

--- a/projects/tests/interactingwavefunction.cpp
+++ b/projects/tests/interactingwavefunction.cpp
@@ -7,7 +7,7 @@
 #include "simplegaussian.hpp"
 #include "interactingwavefunction.hpp"
 
-void EXPECT_BOSON_EQ(const Boson &b1, const Boson &b2, Real tol = -1) {
+void EXPECT_BOSON_EQ(const Vector &b1, const Vector &b2, Real tol = -1) {
     ASSERT_EQ(b1.get_dimensions(), b2.get_dimensions());
     for (int d = 0; d < b1.get_dimensions(); ++d) {
         if (tol > 0)

--- a/projects/tests/samplercheck.cpp
+++ b/projects/tests/samplercheck.cpp
@@ -28,15 +28,15 @@ void sampler_sanity(int sampler_type) {
     System after  = sampler.next_configuration();
 
     EXPECT_EQ(init_system.get_dimensions(), before.get_dimensions());
-    EXPECT_EQ(init_system.get_n_bosons(), before.get_n_bosons());
+    EXPECT_EQ(init_system.get_n_particles(), before.get_n_particles());
     EXPECT_EQ(init_system.get_dimensions(), after.get_dimensions());
-    EXPECT_EQ(init_system.get_n_bosons(), after.get_n_bosons());
+    EXPECT_EQ(init_system.get_n_particles(), after.get_n_particles());
 
     // One one particle should be attempted to move each time.
     // All other particles should remain unchanged, and the moving
     // particle shoudl be changed iff acceptance rate has not decreased.
     for (int run = 1; run <= runs; ++run) {
-        int moving = run % init_system.get_n_bosons();
+        int moving = run % init_system.get_n_particles();
 
         long accepted = sampler.get_accepted_steps();
         long total = sampler.get_total_steps();
@@ -45,7 +45,7 @@ void sampler_sanity(int sampler_type) {
 
         ASSERT_TRUE(total == sampler.get_total_steps() - 1);
 
-        for (int i = 0; i < init_system.get_n_bosons(); ++i) {
+        for (int i = 0; i < init_system.get_n_particles(); ++i) {
             if (i == moving) continue;
             ASSERT_EQ(before[i], after[i]);
         }
@@ -62,7 +62,7 @@ void sampler_sanity(int sampler_type) {
         // Minor, minor rounding error might be here, so every so often a
         // ASSERT_DOUBLE_EQ will fail due to being 5 ULP different, where 4 ULP (unit in the last place)
         // is Google tests limit. This is still good enough. ASSERT_FLOAT_EQ works.
-        ASSERT_NEAR(init_system.get_dimensions() * init_system.get_n_bosons() * 0.5, E_L, 1e-13);
+        ASSERT_NEAR(init_system.get_dimensions() * init_system.get_n_particles() * 0.5, E_L, 1e-13);
     }
 }
 

--- a/projects/tests/simplegaussian.cpp
+++ b/projects/tests/simplegaussian.cpp
@@ -23,7 +23,7 @@ TEST(SimpleGaussian, call_with_beta) {
     SimpleGaussian psi (0.5, 2.8);
 
     // Calculated by hand/calculator:
-    Boson F_0 = {{-1.01667658, -0.15464426, -3.880500176}};
+    Vector F_0 = {{-1.01667658, -0.15464426, -3.880500176}};
     EXPECT_DOUBLE_EQ(0.096971040514681181, psi(s));
     EXPECT_DOUBLE_EQ(-4.666685792898267, psi.derivative_alpha(s));
     for (int d = 0; d < s.get_dimensions(); ++d) {
@@ -47,7 +47,7 @@ TEST(SimpleGaussian, call_2D) {
     EXPECT_DOUBLE_EQ(-91, psi_with_beta.derivative_alpha(s));
     EXPECT_DOUBLE_EQ(-91, psi.derivative_alpha(s));
 
-    Boson F_2 = { {-10, -12} };
+    Vector F_2 = { {-10, -12} };
     for (int d = 0; d < s.get_dimensions(); ++d) {
         EXPECT_EQ(F_2[d], psi.drift_force(s[2], d));
     }

--- a/projects/tests/system.cpp
+++ b/projects/tests/system.cpp
@@ -11,14 +11,14 @@ TEST(System, basics) {
 
     EXPECT_EQ(-123, s[0][0]);
     EXPECT_EQ( 123, s[0][2]);
-    EXPECT_EQ( 10, s.get_n_bosons() );
+    EXPECT_EQ( 10, s.get_n_particles() );
     EXPECT_EQ( 3 , s.get_dimensions() );
 
     System ss = s;
 
     EXPECT_EQ(-123, ss[0][0]);
     EXPECT_EQ( 123, ss[0][2]);
-    EXPECT_EQ( 10, ss.get_n_bosons() );
+    EXPECT_EQ( 10, ss.get_n_particles() );
     EXPECT_EQ( 3 , ss.get_dimensions() );
 }
 
@@ -63,7 +63,7 @@ TEST(System, distances) {
 
         // Changing a boson should trigger a recalculation, even if changed
         // to the existing value;
-        int a = k % s.get_n_bosons();
+        int a = k % s.get_n_particles();
         s(a) = s[a];
 
         for (int i = 0; i < (int) expected.size(); ++i) {

--- a/projects/tests/vector.cpp
+++ b/projects/tests/vector.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 #include "definitions.hpp"
-#include "boson.hpp"
+#include "vector.hpp"
 
 namespace {
     std::default_random_engine rand_gen(12345);
@@ -29,9 +29,9 @@ namespace {
     }
 }
 
-TEST(Boson, basics) {
-    Boson b1(1);
-    Boson b3(3);
+TEST(Vector, basics) {
+    Vector b1(1);
+    Vector b3(3);
     b1[0] = 123.45;
     b3[0] = -1;
     b3[2] = 3;
@@ -44,30 +44,30 @@ TEST(Boson, basics) {
     EXPECT_EQ( 3, b3.get_dimensions() );
 }
 
-TEST(Boson, copy_init) {
-    Boson a(3);
+TEST(Vector, copy_init) {
+    Vector a(3);
     a[1] = 123;
     a[2] = -1;
-    Boson b = a;
-    Boson c = {{0, 123, -1}};
+    Vector b = a;
+    Vector c = {{0, 123, -1}};
     EXPECT_EQ(a, b);
     EXPECT_EQ(a, c);
 }
 
-TEST(Boson, dot_prod) {
+TEST(Vector, dot_prod) {
     for (int i = 0; i < N_RANDOM_TRIALS; i++) {
         int dims = dim_gen();
         std::vector<Real> a_vec = random_vec(dims);
         std::vector<Real> b_vec = random_vec(dims);
-        Boson a (a_vec);
-        Boson b (b_vec);
+        Vector a (a_vec);
+        Vector b (b_vec);
 
         Real expected = std::inner_product(a_vec.begin(), a_vec.end(), b_vec.begin(), (Real) 0.0);
         EXPECT_DOUBLE_EQ(expected, a * b);
     }
 }
 
-TEST(Boson, addSub) {
+TEST(Vector, addSub) {
     for (int i = 0; i < N_RANDOM_TRIALS; i++) {
         int dims = dim_gen();
         std::vector<Real> a_vec = random_vec(dims);
@@ -80,10 +80,10 @@ TEST(Boson, addSub) {
             d_vec[i] = a_vec[i] - b_vec[i];
         }
 
-        Boson a (a_vec);
-        Boson b (b_vec);
-        Boson c (c_vec);
-        Boson d (d_vec);
+        Vector a (a_vec);
+        Vector b (b_vec);
+        Vector c (c_vec);
+        Vector d (d_vec);
 
         ASSERT_TRUE(c == a + b);
         ASSERT_TRUE(d == a - b);
@@ -97,15 +97,15 @@ TEST(Boson, addSub) {
     }
 }
 
-TEST(Boson, scalarOperations) {
+TEST(Vector, scalarOperations) {
     for (int i = 0; i < N_RANDOM_TRIALS; i++) {
         int dims = dim_gen();
         Real scalar = double_gen();
-        Boson a = { random_vec(dims) };
-        Boson b = a * scalar * scalar;
-        Boson c = scalar + a + scalar;
-        Boson d = (- scalar) - a - scalar;
-        Boson e = a / scalar;
+        Vector a = { random_vec(dims) };
+        Vector b = a * scalar * scalar;
+        Vector c = scalar + a + scalar;
+        Vector d = (- scalar) - a - scalar;
+        Vector e = a / scalar;
         for (int i = 0; i < dims; ++i) {
             ASSERT_DOUBLE_EQ(a[i] * square(scalar), b[i]);
             ASSERT_DOUBLE_EQ(scalar + a[i] + scalar, c[i]);
@@ -127,8 +127,8 @@ TEST(Boson, scalarOperations) {
     }
 }
 
-TEST(Boson, display) {
-    Boson b = {{ 1, 2, 3 }};
+TEST(Vector, display) {
+    Vector b = {{ 1, 2, 3 }};
     std::stringstream actual;
     actual << b;
     std::stringstream expected;


### PR DESCRIPTION
A better name for what it is - keeps it more general, and is semantically more usable for project 2. Refactoring helps bigtime with this.